### PR TITLE
Fixes issue with query parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ CssSourcemapPlugin.prototype.apply = function (compiler) {
 
 CssSourcemapPlugin.prototype.processRequest = function (request, loader) {
   var requestParts = request.split('?');
-  var query = loaderUtils.parseQuery(requestParts[1] || '');
+  var query = loaderUtils.parseQuery(!!requestParts[1] ? '?' + requestParts[1] : '');
+  
   switch (loader) {
     case 'css':
     case 'less':


### PR DESCRIPTION
Fixes issue with query parsing (used version webpack 1.12.13).

LoaderUtils expect query-strings to start with an '?', see: https://github.com/webpack/loader-utils
